### PR TITLE
fixed conversion issue with end of row items and produced new stylesheets

### DIFF
--- a/demo/public/minecraft-items-spritesheet.css
+++ b/demo/public/minecraft-items-spritesheet.css
@@ -279,8 +279,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-104; 
-  --j:--1; 
+  --i:-103; 
+  --j:-31; 
 }
 .adult-carrots {
   --n:1; /* scale */
@@ -307,8 +307,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-67; 
-  --j:--1; 
+  --i:-66; 
+  --j:-31; 
 }
 .air {
   --n:1; /* scale */
@@ -412,8 +412,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-26; 
-  --j:--1; 
+  --i:-25; 
+  --j:-31; 
 }
 .amethyst-trim-chainmail-leggings {
   --n:1; /* scale */
@@ -741,8 +741,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-44; 
-  --j:--1; 
+  --i:-43; 
+  --j:-31; 
 }
 .arrow-of-decay-revision-1 {
   --n:1; /* scale */
@@ -1000,8 +1000,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-21; 
-  --j:--1; 
+  --i:-20; 
+  --j:-31; 
 }
 .bamboo-hanging-sign {
   --n:1; /* scale */
@@ -1126,8 +1126,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-21; 
-  --j:--1; 
+  --i:-20; 
+  --j:-31; 
 }
 .bamboo-wood-planks {
   --n:1; /* scale */
@@ -1266,8 +1266,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-2; 
-  --j:--1; 
+  --i:-1; 
+  --j:-31; 
 }
 .bee-spawn-egg {
   --n:1; /* scale */
@@ -1490,8 +1490,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-101; 
-  --j:--1; 
+  --i:-100; 
+  --j:-31; 
 }
 .birch-stairs-left {
   --n:1; /* scale */
@@ -1574,8 +1574,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-101; 
-  --j:--1; 
+  --i:-100; 
+  --j:-31; 
 }
 .birch-wood-trapdoor {
   --n:1; /* scale */
@@ -1609,8 +1609,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-22; 
-  --j:--1; 
+  --i:-21; 
+  --j:-31; 
 }
 .black-banner-15w14a {
   --n:1; /* scale */
@@ -1938,8 +1938,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-80; 
-  --j:--1; 
+  --i:-79; 
+  --j:-31; 
 }
 .black-per-fess-inverted-banner {
   --n:1; /* scale */
@@ -2638,8 +2638,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-81; 
-  --j:--1; 
+  --i:-80; 
+  --j:-31; 
 }
 .blue-paly-banner {
   --n:1; /* scale */
@@ -2967,8 +2967,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-40; 
-  --j:--1; 
+  --i:-39; 
+  --j:-31; 
 }
 .bow-be {
   --n:1; /* scale */
@@ -3128,8 +3128,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-14; 
-  --j:--1; 
+  --i:-13; 
+  --j:-31; 
 }
 .broken-elytra {
   --n:1; /* scale */
@@ -3380,8 +3380,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-82; 
-  --j:--1; 
+  --i:-81; 
+  --j:-31; 
 }
 .brown-glazed-terracotta {
   --n:1; /* scale */
@@ -3870,8 +3870,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-56; 
-  --j:--1; 
+  --i:-55; 
+  --j:-31; 
 }
 .cake {
   --n:1; /* scale */
@@ -4080,8 +4080,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-56; 
-  --j:--1; 
+  --i:-55; 
+  --j:-31; 
 }
 .chain {
   --n:1; /* scale */
@@ -4248,8 +4248,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-37; 
-  --j:--1; 
+  --i:-36; 
+  --j:-31; 
 }
 .cherry-trapdoor {
   --n:1; /* scale */
@@ -4325,8 +4325,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-37; 
-  --j:--1; 
+  --i:-36; 
+  --j:-31; 
 }
 .cherry-wood-trapdoor {
   --n:1; /* scale */
@@ -4682,8 +4682,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-105; 
-  --j:--1; 
+  --i:-104; 
+  --j:-31; 
 }
 .cocoa-beans {
   --n:1; /* scale */
@@ -4724,8 +4724,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-16; 
-  --j:--1; 
+  --i:-15; 
+  --j:-31; 
 }
 .composter {
   --n:1; /* scale */
@@ -4773,8 +4773,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-100; 
-  --j:--1; 
+  --i:-99; 
+  --j:-31; 
 }
 .cooked-cod {
   --n:1; /* scale */
@@ -4899,8 +4899,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-39; 
-  --j:--1; 
+  --i:-38; 
+  --j:-31; 
 }
 .copper-trim-chainmail-boots {
   --n:1; /* scale */
@@ -4920,8 +4920,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-27; 
-  --j:--1; 
+  --i:-26; 
+  --j:-31; 
 }
 .copper-trim-chainmail-leggings {
   --n:1; /* scale */
@@ -5550,8 +5550,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-83; 
-  --j:--1; 
+  --i:-82; 
+  --j:-31; 
 }
 .cyan-chief-indented-banner {
   --n:1; /* scale */
@@ -6201,8 +6201,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-78; 
-  --j:--1; 
+  --i:-77; 
+  --j:-31; 
 }
 .damaged-leather-pants {
   --n:1; /* scale */
@@ -6306,8 +6306,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-111; 
-  --j:--1; 
+  --i:-110; 
+  --j:-31; 
 }
 .damaged-stone-pickaxe {
   --n:1; /* scale */
@@ -6698,8 +6698,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-74; 
-  --j:--1; 
+  --i:-73; 
+  --j:-31; 
 }
 .dead-brain-coral-block {
   --n:1; /* scale */
@@ -7097,8 +7097,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-106; 
-  --j:--1; 
+  --i:-105; 
+  --j:-31; 
 }
 .diamond-pickaxe {
   --n:1; /* scale */
@@ -7279,8 +7279,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-29; 
-  --j:--1; 
+  --i:-28; 
+  --j:-31; 
 }
 .diamond-trim-netherite-leggings {
   --n:1; /* scale */
@@ -7384,8 +7384,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .double-smooth-stone-slab {
   --n:1; /* scale */
@@ -7713,8 +7713,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-30; 
-  --j:--1; 
+  --i:-29; 
+  --j:-31; 
 }
 .emerald-trim-netherite-boots {
   --n:1; /* scale */
@@ -7825,8 +7825,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-11; 
-  --j:--1; 
+  --i:-10; 
+  --j:-31; 
 }
 .end-portal {
   --n:1; /* scale */
@@ -8042,15 +8042,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-25; 
-  --j:--1; 
+  --i:-24; 
+  --j:-31; 
 }
 .eye-armor-trim-smithing-template {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-25; 
-  --j:--1; 
+  --i:-24; 
+  --j:-31; 
 }
 .eye-drops {
   --n:1; /* scale */
@@ -8070,8 +8070,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-12; 
-  --j:--1; 
+  --i:-11; 
+  --j:-31; 
 }
 .farmland {
   --n:1; /* scale */
@@ -8343,8 +8343,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-77; 
-  --j:--1; 
+  --i:-76; 
+  --j:-31; 
 }
 .francium {
   --n:1; /* scale */
@@ -8707,8 +8707,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-31; 
-  --j:--1; 
+  --i:-30; 
+  --j:-31; 
 }
 .gold-trim-iron-helmet {
   --n:1; /* scale */
@@ -9036,8 +9036,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-84; 
-  --j:--1; 
+  --i:-83; 
+  --j:-31; 
 }
 .gray-bordure-banner {
   --n:1; /* scale */
@@ -9449,8 +9449,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-85; 
-  --j:--1; 
+  --i:-84; 
+  --j:-31; 
 }
 .green-base-dexter-canton-banner {
   --n:1; /* scale */
@@ -9708,8 +9708,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-60; 
-  --j:--1; 
+  --i:-59; 
+  --j:-31; 
 }
 .green-lozenge-banner {
   --n:1; /* scale */
@@ -9792,8 +9792,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-86; 
-  --j:--1; 
+  --i:-85; 
+  --j:-31; 
 }
 .green-per-pale-inverted-banner {
   --n:1; /* scale */
@@ -9897,8 +9897,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-23; 
-  --j:--1; 
+  --i:-22; 
+  --j:-31; 
 }
 .green-thing-banner {
   --n:1; /* scale */
@@ -10037,15 +10037,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-61; 
-  --j:--1; 
+  --i:-60; 
+  --j:-31; 
 }
 .hardened-brown-stained-glass-pane {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-62; 
-  --j:--1; 
+  --i:-61; 
+  --j:-31; 
 }
 .hardened-cyan-stained-glass {
   --n:1; /* scale */
@@ -10254,8 +10254,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-102; 
-  --j:--1; 
+  --i:-101; 
+  --j:-31; 
 }
 .head {
   --n:1; /* scale */
@@ -10492,8 +10492,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .host-armor-trim {
   --n:1; /* scale */
@@ -10653,8 +10653,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-50; 
-  --j:--1; 
+  --i:-49; 
+  --j:-31; 
 }
 .initialized-nether-reactor-core-revision-1 {
   --n:1; /* scale */
@@ -10968,8 +10968,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-32; 
-  --j:--1; 
+  --i:-31; 
+  --j:-31; 
 }
 .iron-trim-iron-leggings {
   --n:1; /* scale */
@@ -11241,15 +11241,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-70; 
-  --j:--1; 
+  --i:-69; 
+  --j:-31; 
 }
 .jungle-planks {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-28; 
-  --j:--1; 
+  --i:-27; 
+  --j:-31; 
 }
 .jungle-pressure-plate {
   --n:1; /* scale */
@@ -11339,8 +11339,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-28; 
-  --j:--1; 
+  --i:-27; 
+  --j:-31; 
 }
 .jungle-wood-pressure-plate {
   --n:1; /* scale */
@@ -11451,8 +11451,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-57; 
-  --j:--1; 
+  --i:-56; 
+  --j:-31; 
 }
 .lapis-lazuli {
   --n:1; /* scale */
@@ -11619,8 +11619,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-33; 
-  --j:--1; 
+  --i:-32; 
+  --j:-31; 
 }
 .lapis-trim-netherite-boots {
   --n:1; /* scale */
@@ -11668,8 +11668,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-107; 
-  --j:--1; 
+  --i:-106; 
+  --j:-31; 
 }
 .latex {
   --n:1; /* scale */
@@ -11808,8 +11808,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-65; 
-  --j:--1; 
+  --i:-64; 
+  --j:-31; 
 }
 .leather-pants-revision-2 {
   --n:1; /* scale */
@@ -12396,8 +12396,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-87; 
-  --j:--1; 
+  --i:-86; 
+  --j:-31; 
 }
 .light-blue-per-bend-inverted-banner {
   --n:1; /* scale */
@@ -12844,8 +12844,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-88; 
-  --j:--1; 
+  --i:-87; 
+  --j:-31; 
 }
 .light-gray-jar {
   --n:1; /* scale */
@@ -13138,8 +13138,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-15; 
-  --j:--1; 
+  --i:-14; 
+  --j:-31; 
 }
 .lime-base-banner {
   --n:1; /* scale */
@@ -13229,8 +13229,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-13; 
-  --j:--1; 
+  --i:-12; 
+  --j:-31; 
 }
 .lime-carpet {
   --n:1; /* scale */
@@ -13299,8 +13299,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-89; 
-  --j:--1; 
+  --i:-88; 
+  --j:-31; 
 }
 .lime-cross-banner {
   --n:1; /* scale */
@@ -13544,8 +13544,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-63; 
-  --j:--1; 
+  --i:-62; 
+  --j:-31; 
 }
 .lime-terracotta {
   --n:1; /* scale */
@@ -13684,8 +13684,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-109; 
-  --j:--1; 
+  --i:-108; 
+  --j:-31; 
 }
 .lingering-potion-of-leaping-revision-1 {
   --n:1; /* scale */
@@ -13726,8 +13726,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-10; 
-  --j:--1; 
+  --i:-9; 
+  --j:-31; 
 }
 .lingering-potion-of-poison {
   --n:1; /* scale */
@@ -14167,8 +14167,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-90; 
-  --j:--1; 
+  --i:-89; 
+  --j:-31; 
 }
 .magenta-candle {
   --n:1; /* scale */
@@ -14307,8 +14307,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-47; 
-  --j:--1; 
+  --i:-46; 
+  --j:-31; 
 }
 .magenta-globe-banner {
   --n:1; /* scale */
@@ -14706,8 +14706,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-19; 
-  --j:--1; 
+  --i:-18; 
+  --j:-31; 
 }
 .mangrove-sign {
   --n:1; /* scale */
@@ -14923,8 +14923,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-45; 
-  --j:--1; 
+  --i:-44; 
+  --j:-31; 
 }
 .mhf-arrowright {
   --n:1; /* scale */
@@ -15168,8 +15168,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-46; 
-  --j:--1; 
+  --i:-45; 
+  --j:-31; 
 }
 .mhf-tnt2 {
   --n:1; /* scale */
@@ -15518,8 +15518,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .mundane-lingering-potion {
   --n:1; /* scale */
@@ -15742,8 +15742,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-110; 
-  --j:--1; 
+  --i:-109; 
+  --j:-31; 
 }
 .nether-brick-block {
   --n:1; /* scale */
@@ -15756,8 +15756,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-20; 
-  --j:--1; 
+  --i:-19; 
+  --j:-31; 
 }
 .nether-brick-fence-be {
   --n:1; /* scale */
@@ -16106,8 +16106,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-34; 
-  --j:--1; 
+  --i:-33; 
+  --j:-31; 
 }
 .netherite-trim-leather-pants {
   --n:1; /* scale */
@@ -16610,8 +16610,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-91; 
-  --j:--1; 
+  --i:-90; 
+  --j:-31; 
 }
 .orange-base-indented-banner {
   --n:1; /* scale */
@@ -16967,8 +16967,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-92; 
-  --j:--1; 
+  --i:-91; 
+  --j:-31; 
 }
 .orange-saltire-banner {
   --n:1; /* scale */
@@ -17037,8 +17037,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-24; 
-  --j:--1; 
+  --i:-23; 
+  --j:-31; 
 }
 .orange-stained-glass-pane-be {
   --n:1; /* scale */
@@ -17303,8 +17303,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-54; 
-  --j:--1; 
+  --i:-53; 
+  --j:-31; 
 }
 .phosphorus {
   --n:1; /* scale */
@@ -17492,8 +17492,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-51; 
-  --j:--1; 
+  --i:-50; 
+  --j:-31; 
 }
 .pink-carpet-revision-1 {
   --n:1; /* scale */
@@ -17695,8 +17695,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-93; 
-  --j:--1; 
+  --i:-92; 
+  --j:-31; 
 }
 .pink-per-bend-sinister-inverted-banner {
   --n:1; /* scale */
@@ -18276,8 +18276,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-4; 
-  --j:--1; 
+  --i:-3; 
+  --j:-31; 
 }
 .potato-revision-2 {
   --n:1; /* scale */
@@ -18395,8 +18395,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-108; 
-  --j:--1; 
+  --i:-107; 
+  --j:-31; 
 }
 .potion-of-night-vision-revision-1 {
   --n:1; /* scale */
@@ -18913,8 +18913,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-99; 
-  --j:--1; 
+  --i:-98; 
+  --j:-31; 
 }
 .purple-fess-banner {
   --n:1; /* scale */
@@ -19004,8 +19004,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-94; 
-  --j:--1; 
+  --i:-93; 
+  --j:-31; 
 }
 .purple-pale-dexter-banner {
   --n:1; /* scale */
@@ -19137,8 +19137,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-55; 
-  --j:--1; 
+  --i:-54; 
+  --j:-31; 
 }
 .purple-sparkler-active {
   --n:1; /* scale */
@@ -19207,8 +19207,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-8; 
-  --j:--1; 
+  --i:-7; 
+  --j:-31; 
 }
 .purple-wool {
   --n:1; /* scale */
@@ -19256,8 +19256,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-9; 
-  --j:--1; 
+  --i:-8; 
+  --j:-31; 
 }
 .quartz-pillar {
   --n:1; /* scale */
@@ -19277,8 +19277,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-103; 
-  --j:--1; 
+  --i:-102; 
+  --j:-31; 
 }
 .quartz-trim-chainmail-boots {
   --n:1; /* scale */
@@ -19431,8 +19431,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-35; 
-  --j:--1; 
+  --i:-34; 
+  --j:-31; 
 }
 .quartz-trim-netherite-helmet {
   --n:1; /* scale */
@@ -19487,8 +19487,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-58; 
-  --j:--1; 
+  --i:-57; 
+  --j:-31; 
 }
 .radon {
   --n:1; /* scale */
@@ -19522,8 +19522,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-114; 
-  --j:--1; 
+  --i:-113; 
+  --j:-31; 
 }
 .raiser-armor-trim {
   --n:1; /* scale */
@@ -19599,8 +19599,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-17; 
-  --j:--1; 
+  --i:-16; 
+  --j:-31; 
 }
 .raw-mutton {
   --n:1; /* scale */
@@ -19886,8 +19886,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-95; 
-  --j:--1; 
+  --i:-94; 
+  --j:-31; 
 }
 .red-field-masoned-banner {
   --n:1; /* scale */
@@ -20257,8 +20257,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-41; 
-  --j:--1; 
+  --i:-40; 
+  --j:-31; 
 }
 .red-tinted-glass-pane {
   --n:1; /* scale */
@@ -20292,8 +20292,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-48; 
-  --j:--1; 
+  --i:-47; 
+  --j:-31; 
 }
 .red-wool-revision-2 {
   --n:1; /* scale */
@@ -20789,8 +20789,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-1; 
-  --j:--1; 
+  --i:-0; 
+  --j:-31; 
 }
 .savanna-village-map {
   --n:1; /* scale */
@@ -20957,15 +20957,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-38; 
-  --j:--1; 
+  --i:-37; 
+  --j:-31; 
 }
 .shaper-armor-trim-smithing-template {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-38; 
-  --j:--1; 
+  --i:-37; 
+  --j:-31; 
 }
 .sheaf-pottery-sherd {
   --n:1; /* scale */
@@ -21132,8 +21132,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-43; 
-  --j:--1; 
+  --i:-42; 
+  --j:-31; 
 }
 .skeleton-skull {
   --n:1; /* scale */
@@ -21699,8 +21699,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-77; 
-  --j:--1; 
+  --i:-76; 
+  --j:-31; 
 }
 .spawn-frog {
   --n:1; /* scale */
@@ -21748,8 +21748,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .spawn-husk {
   --n:1; /* scale */
@@ -21930,8 +21930,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-43; 
-  --j:--1; 
+  --i:-42; 
+  --j:-31; 
 }
 .spawn-slime {
   --n:1; /* scale */
@@ -21979,8 +21979,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-18; 
-  --j:--1; 
+  --i:-17; 
+  --j:-31; 
 }
 .spawn-trader-llama {
   --n:1; /* scale */
@@ -22805,8 +22805,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-112; 
-  --j:--1; 
+  --i:-111; 
+  --j:-31; 
 }
 .stone-brick-slab {
   --n:1; /* scale */
@@ -23288,8 +23288,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-18; 
-  --j:--1; 
+  --i:-17; 
+  --j:-31; 
 }
 .tag {
   --n:1; /* scale */
@@ -23540,8 +23540,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-113; 
-  --j:--1; 
+  --i:-112; 
+  --j:-31; 
 }
 .trapped-chest-be {
   --n:1; /* scale */
@@ -23974,8 +23974,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-7; 
-  --j:--1; 
+  --i:-6; 
+  --j:-31; 
 }
 .warped-hanging-sign {
   --n:1; /* scale */
@@ -24016,8 +24016,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-6; 
-  --j:--1; 
+  --i:-5; 
+  --j:-31; 
 }
 .warped-sign {
   --n:1; /* scale */
@@ -24121,8 +24121,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-3; 
-  --j:--1; 
+  --i:-2; 
+  --j:-31; 
 }
 .waxed-block-of-copper {
   --n:1; /* scale */
@@ -24359,8 +24359,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-5; 
-  --j:--1; 
+  --i:-4; 
+  --j:-31; 
 }
 .wet-sponge {
   --n:1; /* scale */
@@ -24527,8 +24527,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-96; 
-  --j:--1; 
+  --i:-95; 
+  --j:-31; 
 }
 .white-chief-dexter-canton-banner {
   --n:1; /* scale */
@@ -24793,8 +24793,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-79; 
-  --j:--1; 
+  --i:-78; 
+  --j:-31; 
 }
 .white-shulker-box {
   --n:1; /* scale */
@@ -25115,8 +25115,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-97; 
-  --j:--1; 
+  --i:-96; 
+  --j:-31; 
 }
 .yellow-beaker {
   --n:1; /* scale */
@@ -25493,8 +25493,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-98; 
-  --j:--1; 
+  --i:-97; 
+  --j:-31; 
 }
 .yellow-snout-banner {
   --n:1; /* scale */
@@ -25598,8 +25598,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-59; 
-  --j:--1; 
+  --i:-58; 
+  --j:-31; 
 }
 .zoglin-spawn-egg {
   --n:1; /* scale */

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -36,8 +36,8 @@ const remap = {
 
 for (const item in items) {
     const i = items[item];
-    const row = (Math.floor(i.pos / 32)) - 1;
-    const column = Math.floor(i.pos % 32) - 1;
+    const row  = Math.floor((i.pos - 1) / 32);
+    const column = (i.pos - 1) % 32;
     let className = item
         .toLowerCase()
         .split(' ')
@@ -47,7 +47,7 @@ for (const item in items) {
         .replace(")", '')
         .replace(".", '');
 
-    if (Object.keys(remap).includes(className)) {
+    if (remap[className]) {
         className = remap[className];
     }
 
@@ -55,7 +55,7 @@ for (const item in items) {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-${row + 1}; 
+  --i:-${row}; 
   --j:-${column}; 
 }
 `;

--- a/src/minecraft-items-spritesheet.css
+++ b/src/minecraft-items-spritesheet.css
@@ -279,8 +279,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-104; 
-  --j:--1; 
+  --i:-103; 
+  --j:-31; 
 }
 .adult-carrots {
   --n:1; /* scale */
@@ -307,8 +307,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-67; 
-  --j:--1; 
+  --i:-66; 
+  --j:-31; 
 }
 .air {
   --n:1; /* scale */
@@ -412,8 +412,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-26; 
-  --j:--1; 
+  --i:-25; 
+  --j:-31; 
 }
 .amethyst-trim-chainmail-leggings {
   --n:1; /* scale */
@@ -741,8 +741,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-44; 
-  --j:--1; 
+  --i:-43; 
+  --j:-31; 
 }
 .arrow-of-decay-revision-1 {
   --n:1; /* scale */
@@ -1000,8 +1000,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-21; 
-  --j:--1; 
+  --i:-20; 
+  --j:-31; 
 }
 .bamboo-hanging-sign {
   --n:1; /* scale */
@@ -1126,8 +1126,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-21; 
-  --j:--1; 
+  --i:-20; 
+  --j:-31; 
 }
 .bamboo-wood-planks {
   --n:1; /* scale */
@@ -1266,8 +1266,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-2; 
-  --j:--1; 
+  --i:-1; 
+  --j:-31; 
 }
 .bee-spawn-egg {
   --n:1; /* scale */
@@ -1490,8 +1490,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-101; 
-  --j:--1; 
+  --i:-100; 
+  --j:-31; 
 }
 .birch-stairs-left {
   --n:1; /* scale */
@@ -1574,8 +1574,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-101; 
-  --j:--1; 
+  --i:-100; 
+  --j:-31; 
 }
 .birch-wood-trapdoor {
   --n:1; /* scale */
@@ -1609,8 +1609,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-22; 
-  --j:--1; 
+  --i:-21; 
+  --j:-31; 
 }
 .black-banner-15w14a {
   --n:1; /* scale */
@@ -1938,8 +1938,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-80; 
-  --j:--1; 
+  --i:-79; 
+  --j:-31; 
 }
 .black-per-fess-inverted-banner {
   --n:1; /* scale */
@@ -2638,8 +2638,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-81; 
-  --j:--1; 
+  --i:-80; 
+  --j:-31; 
 }
 .blue-paly-banner {
   --n:1; /* scale */
@@ -2967,8 +2967,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-40; 
-  --j:--1; 
+  --i:-39; 
+  --j:-31; 
 }
 .bow-be {
   --n:1; /* scale */
@@ -3128,8 +3128,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-14; 
-  --j:--1; 
+  --i:-13; 
+  --j:-31; 
 }
 .broken-elytra {
   --n:1; /* scale */
@@ -3380,8 +3380,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-82; 
-  --j:--1; 
+  --i:-81; 
+  --j:-31; 
 }
 .brown-glazed-terracotta {
   --n:1; /* scale */
@@ -3870,8 +3870,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-56; 
-  --j:--1; 
+  --i:-55; 
+  --j:-31; 
 }
 .cake {
   --n:1; /* scale */
@@ -4080,8 +4080,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-56; 
-  --j:--1; 
+  --i:-55; 
+  --j:-31; 
 }
 .chain {
   --n:1; /* scale */
@@ -4248,8 +4248,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-37; 
-  --j:--1; 
+  --i:-36; 
+  --j:-31; 
 }
 .cherry-trapdoor {
   --n:1; /* scale */
@@ -4325,8 +4325,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-37; 
-  --j:--1; 
+  --i:-36; 
+  --j:-31; 
 }
 .cherry-wood-trapdoor {
   --n:1; /* scale */
@@ -4682,8 +4682,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-105; 
-  --j:--1; 
+  --i:-104; 
+  --j:-31; 
 }
 .cocoa-beans {
   --n:1; /* scale */
@@ -4724,8 +4724,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-16; 
-  --j:--1; 
+  --i:-15; 
+  --j:-31; 
 }
 .composter {
   --n:1; /* scale */
@@ -4773,8 +4773,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-100; 
-  --j:--1; 
+  --i:-99; 
+  --j:-31; 
 }
 .cooked-cod {
   --n:1; /* scale */
@@ -4899,8 +4899,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-39; 
-  --j:--1; 
+  --i:-38; 
+  --j:-31; 
 }
 .copper-trim-chainmail-boots {
   --n:1; /* scale */
@@ -4920,8 +4920,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-27; 
-  --j:--1; 
+  --i:-26; 
+  --j:-31; 
 }
 .copper-trim-chainmail-leggings {
   --n:1; /* scale */
@@ -5550,8 +5550,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-83; 
-  --j:--1; 
+  --i:-82; 
+  --j:-31; 
 }
 .cyan-chief-indented-banner {
   --n:1; /* scale */
@@ -6201,8 +6201,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-78; 
-  --j:--1; 
+  --i:-77; 
+  --j:-31; 
 }
 .damaged-leather-pants {
   --n:1; /* scale */
@@ -6306,8 +6306,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-111; 
-  --j:--1; 
+  --i:-110; 
+  --j:-31; 
 }
 .damaged-stone-pickaxe {
   --n:1; /* scale */
@@ -6698,8 +6698,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-74; 
-  --j:--1; 
+  --i:-73; 
+  --j:-31; 
 }
 .dead-brain-coral-block {
   --n:1; /* scale */
@@ -7097,8 +7097,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-106; 
-  --j:--1; 
+  --i:-105; 
+  --j:-31; 
 }
 .diamond-pickaxe {
   --n:1; /* scale */
@@ -7279,8 +7279,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-29; 
-  --j:--1; 
+  --i:-28; 
+  --j:-31; 
 }
 .diamond-trim-netherite-leggings {
   --n:1; /* scale */
@@ -7384,8 +7384,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .double-smooth-stone-slab {
   --n:1; /* scale */
@@ -7713,8 +7713,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-30; 
-  --j:--1; 
+  --i:-29; 
+  --j:-31; 
 }
 .emerald-trim-netherite-boots {
   --n:1; /* scale */
@@ -7825,8 +7825,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-11; 
-  --j:--1; 
+  --i:-10; 
+  --j:-31; 
 }
 .end-portal {
   --n:1; /* scale */
@@ -8042,15 +8042,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-25; 
-  --j:--1; 
+  --i:-24; 
+  --j:-31; 
 }
 .eye-armor-trim-smithing-template {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-25; 
-  --j:--1; 
+  --i:-24; 
+  --j:-31; 
 }
 .eye-drops {
   --n:1; /* scale */
@@ -8070,8 +8070,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-12; 
-  --j:--1; 
+  --i:-11; 
+  --j:-31; 
 }
 .farmland {
   --n:1; /* scale */
@@ -8343,8 +8343,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-77; 
-  --j:--1; 
+  --i:-76; 
+  --j:-31; 
 }
 .francium {
   --n:1; /* scale */
@@ -8707,8 +8707,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-31; 
-  --j:--1; 
+  --i:-30; 
+  --j:-31; 
 }
 .gold-trim-iron-helmet {
   --n:1; /* scale */
@@ -9036,8 +9036,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-84; 
-  --j:--1; 
+  --i:-83; 
+  --j:-31; 
 }
 .gray-bordure-banner {
   --n:1; /* scale */
@@ -9449,8 +9449,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-85; 
-  --j:--1; 
+  --i:-84; 
+  --j:-31; 
 }
 .green-base-dexter-canton-banner {
   --n:1; /* scale */
@@ -9708,8 +9708,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-60; 
-  --j:--1; 
+  --i:-59; 
+  --j:-31; 
 }
 .green-lozenge-banner {
   --n:1; /* scale */
@@ -9792,8 +9792,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-86; 
-  --j:--1; 
+  --i:-85; 
+  --j:-31; 
 }
 .green-per-pale-inverted-banner {
   --n:1; /* scale */
@@ -9897,8 +9897,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-23; 
-  --j:--1; 
+  --i:-22; 
+  --j:-31; 
 }
 .green-thing-banner {
   --n:1; /* scale */
@@ -10037,15 +10037,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-61; 
-  --j:--1; 
+  --i:-60; 
+  --j:-31; 
 }
 .hardened-brown-stained-glass-pane {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-62; 
-  --j:--1; 
+  --i:-61; 
+  --j:-31; 
 }
 .hardened-cyan-stained-glass {
   --n:1; /* scale */
@@ -10254,8 +10254,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-102; 
-  --j:--1; 
+  --i:-101; 
+  --j:-31; 
 }
 .head {
   --n:1; /* scale */
@@ -10492,8 +10492,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .host-armor-trim {
   --n:1; /* scale */
@@ -10653,8 +10653,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-50; 
-  --j:--1; 
+  --i:-49; 
+  --j:-31; 
 }
 .initialized-nether-reactor-core-revision-1 {
   --n:1; /* scale */
@@ -10968,8 +10968,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-32; 
-  --j:--1; 
+  --i:-31; 
+  --j:-31; 
 }
 .iron-trim-iron-leggings {
   --n:1; /* scale */
@@ -11241,15 +11241,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-70; 
-  --j:--1; 
+  --i:-69; 
+  --j:-31; 
 }
 .jungle-planks {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-28; 
-  --j:--1; 
+  --i:-27; 
+  --j:-31; 
 }
 .jungle-pressure-plate {
   --n:1; /* scale */
@@ -11339,8 +11339,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-28; 
-  --j:--1; 
+  --i:-27; 
+  --j:-31; 
 }
 .jungle-wood-pressure-plate {
   --n:1; /* scale */
@@ -11451,8 +11451,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-57; 
-  --j:--1; 
+  --i:-56; 
+  --j:-31; 
 }
 .lapis-lazuli {
   --n:1; /* scale */
@@ -11619,8 +11619,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-33; 
-  --j:--1; 
+  --i:-32; 
+  --j:-31; 
 }
 .lapis-trim-netherite-boots {
   --n:1; /* scale */
@@ -11668,8 +11668,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-107; 
-  --j:--1; 
+  --i:-106; 
+  --j:-31; 
 }
 .latex {
   --n:1; /* scale */
@@ -11808,8 +11808,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-65; 
-  --j:--1; 
+  --i:-64; 
+  --j:-31; 
 }
 .leather-pants-revision-2 {
   --n:1; /* scale */
@@ -12396,8 +12396,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-87; 
-  --j:--1; 
+  --i:-86; 
+  --j:-31; 
 }
 .light-blue-per-bend-inverted-banner {
   --n:1; /* scale */
@@ -12844,8 +12844,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-88; 
-  --j:--1; 
+  --i:-87; 
+  --j:-31; 
 }
 .light-gray-jar {
   --n:1; /* scale */
@@ -13138,8 +13138,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-15; 
-  --j:--1; 
+  --i:-14; 
+  --j:-31; 
 }
 .lime-base-banner {
   --n:1; /* scale */
@@ -13229,8 +13229,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-13; 
-  --j:--1; 
+  --i:-12; 
+  --j:-31; 
 }
 .lime-carpet {
   --n:1; /* scale */
@@ -13299,8 +13299,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-89; 
-  --j:--1; 
+  --i:-88; 
+  --j:-31; 
 }
 .lime-cross-banner {
   --n:1; /* scale */
@@ -13544,8 +13544,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-63; 
-  --j:--1; 
+  --i:-62; 
+  --j:-31; 
 }
 .lime-terracotta {
   --n:1; /* scale */
@@ -13684,8 +13684,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-109; 
-  --j:--1; 
+  --i:-108; 
+  --j:-31; 
 }
 .lingering-potion-of-leaping-revision-1 {
   --n:1; /* scale */
@@ -13726,8 +13726,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-10; 
-  --j:--1; 
+  --i:-9; 
+  --j:-31; 
 }
 .lingering-potion-of-poison {
   --n:1; /* scale */
@@ -14167,8 +14167,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-90; 
-  --j:--1; 
+  --i:-89; 
+  --j:-31; 
 }
 .magenta-candle {
   --n:1; /* scale */
@@ -14307,8 +14307,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-47; 
-  --j:--1; 
+  --i:-46; 
+  --j:-31; 
 }
 .magenta-globe-banner {
   --n:1; /* scale */
@@ -14706,8 +14706,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-19; 
-  --j:--1; 
+  --i:-18; 
+  --j:-31; 
 }
 .mangrove-sign {
   --n:1; /* scale */
@@ -14923,8 +14923,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-45; 
-  --j:--1; 
+  --i:-44; 
+  --j:-31; 
 }
 .mhf-arrowright {
   --n:1; /* scale */
@@ -15168,8 +15168,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-46; 
-  --j:--1; 
+  --i:-45; 
+  --j:-31; 
 }
 .mhf-tnt2 {
   --n:1; /* scale */
@@ -15518,8 +15518,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .mundane-lingering-potion {
   --n:1; /* scale */
@@ -15742,8 +15742,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-110; 
-  --j:--1; 
+  --i:-109; 
+  --j:-31; 
 }
 .nether-brick-block {
   --n:1; /* scale */
@@ -15756,8 +15756,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-20; 
-  --j:--1; 
+  --i:-19; 
+  --j:-31; 
 }
 .nether-brick-fence-be {
   --n:1; /* scale */
@@ -16106,8 +16106,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-34; 
-  --j:--1; 
+  --i:-33; 
+  --j:-31; 
 }
 .netherite-trim-leather-pants {
   --n:1; /* scale */
@@ -16610,8 +16610,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-91; 
-  --j:--1; 
+  --i:-90; 
+  --j:-31; 
 }
 .orange-base-indented-banner {
   --n:1; /* scale */
@@ -16967,8 +16967,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-92; 
-  --j:--1; 
+  --i:-91; 
+  --j:-31; 
 }
 .orange-saltire-banner {
   --n:1; /* scale */
@@ -17037,8 +17037,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-24; 
-  --j:--1; 
+  --i:-23; 
+  --j:-31; 
 }
 .orange-stained-glass-pane-be {
   --n:1; /* scale */
@@ -17303,8 +17303,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-54; 
-  --j:--1; 
+  --i:-53; 
+  --j:-31; 
 }
 .phosphorus {
   --n:1; /* scale */
@@ -17492,8 +17492,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-51; 
-  --j:--1; 
+  --i:-50; 
+  --j:-31; 
 }
 .pink-carpet-revision-1 {
   --n:1; /* scale */
@@ -17695,8 +17695,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-93; 
-  --j:--1; 
+  --i:-92; 
+  --j:-31; 
 }
 .pink-per-bend-sinister-inverted-banner {
   --n:1; /* scale */
@@ -18276,8 +18276,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-4; 
-  --j:--1; 
+  --i:-3; 
+  --j:-31; 
 }
 .potato-revision-2 {
   --n:1; /* scale */
@@ -18395,8 +18395,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-108; 
-  --j:--1; 
+  --i:-107; 
+  --j:-31; 
 }
 .potion-of-night-vision-revision-1 {
   --n:1; /* scale */
@@ -18913,8 +18913,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-99; 
-  --j:--1; 
+  --i:-98; 
+  --j:-31; 
 }
 .purple-fess-banner {
   --n:1; /* scale */
@@ -19004,8 +19004,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-94; 
-  --j:--1; 
+  --i:-93; 
+  --j:-31; 
 }
 .purple-pale-dexter-banner {
   --n:1; /* scale */
@@ -19137,8 +19137,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-55; 
-  --j:--1; 
+  --i:-54; 
+  --j:-31; 
 }
 .purple-sparkler-active {
   --n:1; /* scale */
@@ -19207,8 +19207,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-8; 
-  --j:--1; 
+  --i:-7; 
+  --j:-31; 
 }
 .purple-wool {
   --n:1; /* scale */
@@ -19256,8 +19256,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-9; 
-  --j:--1; 
+  --i:-8; 
+  --j:-31; 
 }
 .quartz-pillar {
   --n:1; /* scale */
@@ -19277,8 +19277,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-103; 
-  --j:--1; 
+  --i:-102; 
+  --j:-31; 
 }
 .quartz-trim-chainmail-boots {
   --n:1; /* scale */
@@ -19431,8 +19431,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-35; 
-  --j:--1; 
+  --i:-34; 
+  --j:-31; 
 }
 .quartz-trim-netherite-helmet {
   --n:1; /* scale */
@@ -19487,8 +19487,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-58; 
-  --j:--1; 
+  --i:-57; 
+  --j:-31; 
 }
 .radon {
   --n:1; /* scale */
@@ -19522,8 +19522,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-114; 
-  --j:--1; 
+  --i:-113; 
+  --j:-31; 
 }
 .raiser-armor-trim {
   --n:1; /* scale */
@@ -19599,8 +19599,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-17; 
-  --j:--1; 
+  --i:-16; 
+  --j:-31; 
 }
 .raw-mutton {
   --n:1; /* scale */
@@ -19886,8 +19886,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-95; 
-  --j:--1; 
+  --i:-94; 
+  --j:-31; 
 }
 .red-field-masoned-banner {
   --n:1; /* scale */
@@ -20257,8 +20257,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-41; 
-  --j:--1; 
+  --i:-40; 
+  --j:-31; 
 }
 .red-tinted-glass-pane {
   --n:1; /* scale */
@@ -20292,8 +20292,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-48; 
-  --j:--1; 
+  --i:-47; 
+  --j:-31; 
 }
 .red-wool-revision-2 {
   --n:1; /* scale */
@@ -20789,8 +20789,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-1; 
-  --j:--1; 
+  --i:-0; 
+  --j:-31; 
 }
 .savanna-village-map {
   --n:1; /* scale */
@@ -20957,15 +20957,15 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-38; 
-  --j:--1; 
+  --i:-37; 
+  --j:-31; 
 }
 .shaper-armor-trim-smithing-template {
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-38; 
-  --j:--1; 
+  --i:-37; 
+  --j:-31; 
 }
 .sheaf-pottery-sherd {
   --n:1; /* scale */
@@ -21132,8 +21132,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-43; 
-  --j:--1; 
+  --i:-42; 
+  --j:-31; 
 }
 .skeleton-skull {
   --n:1; /* scale */
@@ -21699,8 +21699,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-77; 
-  --j:--1; 
+  --i:-76; 
+  --j:-31; 
 }
 .spawn-frog {
   --n:1; /* scale */
@@ -21748,8 +21748,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-36; 
-  --j:--1; 
+  --i:-35; 
+  --j:-31; 
 }
 .spawn-husk {
   --n:1; /* scale */
@@ -21930,8 +21930,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-43; 
-  --j:--1; 
+  --i:-42; 
+  --j:-31; 
 }
 .spawn-slime {
   --n:1; /* scale */
@@ -21979,8 +21979,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-18; 
-  --j:--1; 
+  --i:-17; 
+  --j:-31; 
 }
 .spawn-trader-llama {
   --n:1; /* scale */
@@ -22805,8 +22805,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-112; 
-  --j:--1; 
+  --i:-111; 
+  --j:-31; 
 }
 .stone-brick-slab {
   --n:1; /* scale */
@@ -23288,8 +23288,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-18; 
-  --j:--1; 
+  --i:-17; 
+  --j:-31; 
 }
 .tag {
   --n:1; /* scale */
@@ -23540,8 +23540,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-113; 
-  --j:--1; 
+  --i:-112; 
+  --j:-31; 
 }
 .trapped-chest-be {
   --n:1; /* scale */
@@ -23974,8 +23974,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-7; 
-  --j:--1; 
+  --i:-6; 
+  --j:-31; 
 }
 .warped-hanging-sign {
   --n:1; /* scale */
@@ -24016,8 +24016,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-6; 
-  --j:--1; 
+  --i:-5; 
+  --j:-31; 
 }
 .warped-sign {
   --n:1; /* scale */
@@ -24121,8 +24121,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-3; 
-  --j:--1; 
+  --i:-2; 
+  --j:-31; 
 }
 .waxed-block-of-copper {
   --n:1; /* scale */
@@ -24359,8 +24359,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-5; 
-  --j:--1; 
+  --i:-4; 
+  --j:-31; 
 }
 .wet-sponge {
   --n:1; /* scale */
@@ -24527,8 +24527,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-96; 
-  --j:--1; 
+  --i:-95; 
+  --j:-31; 
 }
 .white-chief-dexter-canton-banner {
   --n:1; /* scale */
@@ -24793,8 +24793,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-79; 
-  --j:--1; 
+  --i:-78; 
+  --j:-31; 
 }
 .white-shulker-box {
   --n:1; /* scale */
@@ -25115,8 +25115,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-97; 
-  --j:--1; 
+  --i:-96; 
+  --j:-31; 
 }
 .yellow-beaker {
   --n:1; /* scale */
@@ -25493,8 +25493,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-98; 
-  --j:--1; 
+  --i:-97; 
+  --j:-31; 
 }
 .yellow-snout-banner {
   --n:1; /* scale */
@@ -25598,8 +25598,8 @@
   --n:1; /* scale */
   
   /* coordinates of the image */
-  --i:-59; 
-  --j:--1; 
+  --i:-58; 
+  --j:-31; 
 }
 .zoglin-spawn-egg {
   --n:1; /* scale */


### PR DESCRIPTION
I jumped the gun a bit with #2 in terms of solution and understanding of the problem (at least at first), but I think I've got it now. I've minimally refactored the conversion code to correctly generate the `i` and `j` position on items that were at the end of a row. In addition to that, I've generated new style sheets and used the demo to verify the fix was effective.